### PR TITLE
Add comma after / in edit descriptor in format

### DIFF
--- a/src/input.f90
+++ b/src/input.f90
@@ -160,9 +160,9 @@ MODULE input_module
     127 FORMAT( 5X, 'nmom= ', I3, /,                                   &
                 5X, 'nang= ', I4 )
 
-    128 FORMAT( 5X, 'ng= ', I4, /                                      &
-                5X, 'mat_opt= ', I2, /                                 &
-                5X, 'src_opt= ', I2, /                                 &
+    128 FORMAT( 5X, 'ng= ', I4, /,                                     &
+                5X, 'mat_opt= ', I2, /,                                &
+                5X, 'src_opt= ', I2, /,                                &
                 5X, 'scatp= ', I2 )
 
     129 FORMAT( 5X, 'epsi= ', ES11.4, /,                               &
@@ -173,7 +173,7 @@ MODULE input_module
                 5X, 'nsteps= ', I5, /,                                 &
                 5X, 'swp_typ= ', I2, /,                                &
                 5X, 'multiswp= ', I2, /,                               &
-                5X, 'angcpy= ', I2, /                                  &
+                5X, 'angcpy= ', I2, /,                                 &
                 5X, 'it_det= ', I2, /,                                 &
                 5X, 'soloutp= ', I2, /,                                &
                 5X, 'kplane= ', I4, /,                                 &

--- a/src/setup.f90
+++ b/src/setup.f90
@@ -879,9 +879,9 @@ MODULE setup_module
     182 FORMAT( 4X, 'npey = ', I5, /, 4X, 'npez = ', I5, /, 4X,        &
                 'nthreads = ', I4, / )
     183 FORMAT( 10X, 'Thread Support Level', /,                        &
-                10X, I2, ' - MPI_THREAD_SINGLE', /                     &
-                10X, I2, ' - MPI_THREAD_FUNNELED', /                   &
-                10X, I2, ' - MPI_THREAD_SERIALIZED', /                 &
+                10X, I2, ' - MPI_THREAD_SINGLE', /,                    &
+                10X, I2, ' - MPI_THREAD_FUNNELED', /,                  &
+                10X, I2, ' - MPI_THREAD_SERIALIZED', /,                &
                 10X, I2, ' - MPI_THREAD_MULTIPLE' )
     184 FORMAT( 4X, 'thread_level = ', I2, / )
     185 FORMAT( 4X, '.TRUE. nested threading', /, 6X, 'nnested = ',    &


### PR DESCRIPTION
I looked into the Fortran 2018 Standard, and in the section
"13.3 Form of a format item list", the relevant syntax rules are:

    R1303 format-items      is format-item [ [ , ] format-item ] ...

    R1304 format-item       is [ r ] data-edit-desc
                            or control-edit-desc
                            or char-string-edit-desc
                            or [ r ] ( format-items )

    R1313 control-edit-desc is position-edit-desc
                            or [r]/
                            or :
                            or sign-edit-desc
                            or k P
                            or blank-interp-edit-desc
                            or round-edit-desc
                            or decimal-edit-desc

If I interpret this correctly, it says that there must be a comma after "/".