### PR TITLE
Add a comma between strings in format()

### DIFF
--- a/src/output.f90
+++ b/src/output.f90
@@ -360,12 +360,12 @@ MODULE output_module
     END IF
 !_______________________________________________________________________
 
-    321 FORMAT( 1X, 'flux(nx,ny,nz,ng) echo', /, 1X, 'Column-order '   &
-                'loops: x-cells (fastest), y-cells, z-cells, groups '  &
+    321 FORMAT( 1X, 'flux(nx,ny,nz,ng) echo', /, 1X, 'Column-order ',  &
+                'loops: x-cells (fastest), y-cells, z-cells, groups ', &
                 '(slowest)' )
-    322 FORMAT( 1X, 'flux(nx,ny,nz,ng) and fluxm(cmom-1,nx,ny,nz,ng)'  &
+    322 FORMAT( 1X, 'flux(nx,ny,nz,ng) and fluxm(cmom-1,nx,ny,nz,ng)', &
                 ' echo', /, 1X, 'Column-order loops by moment:', /,    &
-                1X, 'x-cells (fastest), y-cells, z-cells, groups, '    &
+                1X, 'x-cells (fastest), y-cells, z-cells, groups, ',   &
                 'moments (slowest)' )
     323 FORMAT( /, 2X, 'Moment = ', I1 )
     324 FORMAT( 4(2X, ES17.10) )

--- a/src/setup.f90
+++ b/src/setup.f90
@@ -856,7 +856,7 @@ MODULE setup_module
     148 FORMAT( 2X, 'Pseudo Cross Sections Data' )
     149 FORMAT( 4X, 'ng = ', I3 )
     150 FORMAT( /, 4X, 'Material ', I1 )
-    151 FORMAT( 4X, 'Group         Total         Absorption      '     &
+    151 FORMAT( 4X, 'Group         Total         Absorption      ',    &
                'Scattering' )
     152 FORMAT( 5X, I3, 6X, ES13.6, 3X, ES13.6, 3X, ES13.6 )
 
@@ -941,7 +941,7 @@ MODULE setup_module
     CALL close_file ( fu, ierr, error )
 !_______________________________________________________________________
 
-    161 FORMAT( 'slgg(nmat,nmom,ng,ng) echo', /, 'Column-order loops:' &
+    161 FORMAT( 'slgg(nmat,nmom,ng,ng) echo', /, 'Column-order loops:',&
                 ' Mats (fastest ), Moments, Groups, Groups (slowest)' )
     162 FORMAT( 2X, ES15.8, 2X, ES15.8, 2X, ES15.8, 2X, ES15.8 )
 !_______________________________________________________________________

--- a/src/translv.f90
+++ b/src/translv.f90
@@ -387,7 +387,7 @@ SUBROUTINE translv ( ndpwds )
   208 FORMAT( /, 2X, 'No. Outers=', I4, 4X, 'No. Inners=', I5 )
   209 FORMAT( /, 2X, '*WARNING: Unconverged outer iteration!', /, 2X,  &
               'No. Outers=', I4, 4X, 'No. Inners=', I5, / )
-  210 FORMAT( /, 1X, 30A, /, 2X, 'Total inners for all time steps, '   &
+  210 FORMAT( /, 1X, 30A, /, 2X, 'Total inners for all time steps, ',  &
               'outers = ', I6 )
   211 FORMAT( /, 80A, / )
 !_______________________________________________________________________


### PR DESCRIPTION
I tested the following code in GFortran:

    print 10
    print 11
    10 format('abc' 'de' 'f' 'g' 'h')
    11 format('abc','de','f','g','h')
    end

and it prints:

    abcdefgh
    abcdefgh

So it seems the 'a' 'b' is equivalent to 'a','b'. The latter compiles
with the latest NAG compiler and it seems to be standard Fortran 95,
unlike my previously proposed change in #16.

This is the only change needed to get SNAP compile with NAG, everything
else works.

Fixes #15.